### PR TITLE
refactor: replace `any` with generics for Airtable fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,3 +27,8 @@ export interface AirtableCachedGeocode {
   /** cache expiry, in epoch milliseconds */
   e: number
 }
+
+export interface AirtableGeoJSONErrors<F> {
+  missingGeocodes: Airtable.Record<F>[]
+  invalidGeocodes: Airtable.Record<F>[]
+}


### PR DESCRIPTION
for better typing on the consumer side